### PR TITLE
11/15イベント情報更新

### DIFF
--- a/event.html
+++ b/event.html
@@ -76,48 +76,6 @@
     <div class = "flexslider">
       <ul class = "slides">
         <li>
-          <a href = "event.html#8">
-            <div class = "latestBox_future">
-              <div class = "remaindays_future">
-                <div class = "caption">
-                <script>countdown(20161112,20161113);</script>
-                </div>
-              </div>
-              <img src="images/event/event8.gif" alt="おもしろ写真deアニメーション">
-              <div class = "eventText">
-                <p class = "eventsch caption FCHcolor">
-                  11/12(土) 13(日)
-                </p>
-                <p class = "eventtitle">おもしろ写真deアニメーション</p>
-                <p class = "eventplace caption">
-                  はこだてみらい館
-                </p>
-              </div>
-            </div>
-          </a>
-        </li>
-        <li>
-          <a href = "event.html#12">
-            <div class = "latestBox_kids">
-              <div class = "remaindays_kids">
-                <div class = "caption">
-                <script>countdown(20161113);</script>
-                </div>
-              </div>
-              <img src="images/event/event12.jpg" alt="パントマイムSHOW">
-              <div class = "eventText">
-                <p class = "eventsch caption KPHcolor">
-                  11月13日(日)
-                </p>
-                <p class = "eventtitle">パントマイムSHOW</p>
-                <p class = "eventplace caption">
-                  はこだてキッズプラザ
-                </p>
-              </div>
-            </div>
-          </a>
-        </li>
-        <li>
           <a href = "event.html#9">
             <div class = "latestBox_future">
               <div class = "remaindays_future">
@@ -159,7 +117,7 @@
             </div>
           </a>
         </li>
-        <!-- <li>
+        <li>
           <a href = "event.html#13">
             <div class = "latestBox_kids">
               <div class = "remaindays_kids">
@@ -179,7 +137,7 @@
               </div>
             </div>
           </a>
-        </li> -->
+        </li>
       </ul>
     </div>
   </div>
@@ -253,133 +211,6 @@
 <div class="g_allArea g_allArea-bgcolor">
   <div id = "all_eventmenu">
     <!-- 以下新イベント追加分 -->
-    <div class = "eventmenu" id="8">
-      <img class = "event_pic only_pc" src = "images/event/sq_event8.gif"  alt = "おもしろ写真deアニメーション">
-      <img class = "event_pic only_sp" src = "images/event/event8.gif" alt = "おもしろ写真deアニメーション">
-      <div class = "event_textBox_wrap">
-        <div class = "event_textBox">
-          <div class = "event_title FCHcolor">
-            おもしろ写真deアニメーション
-          </div>
-          <div class = "event_point">
-            <table>
-              <tr>
-                <th class = "event_point_cap">日時</th>
-                <td class = "event_point_contents">
-                  <div class="event_point_contents-text">
-                    11月12日(土) 13日(日)<br>
-                    10:30-12:30(1回目)　14:00-16:00(2回目)<br>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <th class = "event_point_cap">会場</th>
-                <td class = "event_point_contents">はこだてみらい館</td>
-              </tr>
-              <tr>
-                <th class = "event_point_cap">参加費</th>
-                <td class = "event_point_contents">
-                  <div class="event_point_contents-text">
-                    無料
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <th class = "event_point_cap">対象</th>
-                <td class = "event_point_contents">
-                  <div class="event_point_contents-text">
-                    小学生から大人まで　※保護者同伴も可
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <th class = "event_point_cap">定員</th>
-                <td class = "event_point_contents">
-                  <div class="event_point_contents-text">
-                    各回20名
-                  </div>
-                </td>
-              </tr>
-            </table>
-          </div>
-          <div class = "event_detail-short event_detail-overflow">
-            写真のおもしろさは、ただ記録することだけじゃありません。<br>
-            何気ない風景も、写真にすれば工夫次第で別世界に！<br>
-            はこだてみらい館で撮影したおもしろ写真に動きをつけて<br>
-            世界で一つのアニメーション作品を作ってみよう！<br>
-            ・監修：原田泰さん(公立はこだて未来大学教授)
-            <div class = "eventDetail_picBox">
-              <img class = "eventDetail_pic" src = "images/event/c-event8/01.gif">
-            </div>
-          </div>
-        </div>
-        <form action = "event_subscript.php" method = "get">
-          <div class = "subscription">
-            <input type="hidden" name="id" value="8">
-            <input type="submit" value="申し込む" class = "button">
-            <!--<div class = "panel">
-              <p class = "panelLabel">応募終了</p>
-            </div>-->
-          </div>
-        </form>
-      </div>
-    </div>
-    <div class = "eventmenu" id="12">
-      <img class = "event_pic only_pc" src = "images/event/sq_event12.jpg"  alt = "パントマイムSHOW">
-      <img class = "event_pic only_sp" src = "images/event/event12.jpg" alt = "パントマイムSHOW">
-      <div class = "event_textBox_wrap">
-        <div class = "event_textBox">
-          <div class = "event_title KPHcolor">
-            パントマイムSHOW
-          </div>
-          <div class = "event_point">
-            <table>
-              <tr>
-                <th class = "event_point_cap">日時</th>
-                <td class = "event_point_contents">
-                  <div class="event_point_contents-text">
-                    11月13日(日)<br>
-                    12:00-12:15(1回目)　15:00-15:15(2回目)
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <th class = "event_point_cap">会場</th>
-                <td class = "event_point_contents">はこだてキッズプラザ　テラス前</td>
-              </tr>
-              <tr>
-                <th class = "event_point_cap">参加費</th>
-                <td class = "event_point_contents">
-                  <div class="event_point_contents-text">
-                    無料
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <th class = "event_point_cap">対象</th>
-                <td class = "event_point_contents">
-                  <div class="event_point_contents-text">
-                    小さい子から大きい子まで
-                  </div>
-                </td>
-              </tr>
-            </table>
-          </div>
-          <div class = "event_detail-short">
-            キッズプラザのスタッフによるいつも大盛り上がりのパントマイムショー！<br>
-            テラス前をステージに、いろんなネタを披露します。<br>
-            ショーの途中から子どもにも参加していただきます！
-          </div>
-        </div>
-        <form action = "event_subscript.php" method = "get">
-          <div class = "subscription">
-            <div class = "panel">
-              <p class = "panelLabel">※事前申込不要</p>
-            </div>
-          </div>
-        </form>
-      </div>
-    </div>
     <div class = "eventmenu" id="9">
       <img class = "event_pic only_pc" src = "images/event/sq_event9.jpg"  alt = "FabLabワークショップ">
       <img class = "event_pic only_sp" src = "images/event/event9.jpg" alt = "FabLabワークショップ">

--- a/event_finished.html
+++ b/event_finished.html
@@ -843,3 +843,176 @@
         </form>
       </div>
     </div> --> 
+
+    <!-- <li>
+          <a href = "event.html#8">
+            <div class = "latestBox_future">
+              <div class = "remaindays_future">
+                <div class = "caption">
+                <script>countdown(20161112,20161113);</script>
+                </div>
+              </div>
+              <img src="images/event/event8.gif" alt="おもしろ写真deアニメーション">
+              <div class = "eventText">
+                <p class = "eventsch caption FCHcolor">
+                  11/12(土) 13(日)
+                </p>
+                <p class = "eventtitle">おもしろ写真deアニメーション</p>
+                <p class = "eventplace caption">
+                  はこだてみらい館
+                </p>
+              </div>
+            </div>
+          </a>
+        </li> --> 
+
+    <!-- <div class = "eventmenu" id="8">
+      <img class = "event_pic only_pc" src = "images/event/sq_event8.gif"  alt = "おもしろ写真deアニメーション">
+      <img class = "event_pic only_sp" src = "images/event/event8.gif" alt = "おもしろ写真deアニメーション">
+      <div class = "event_textBox_wrap">
+        <div class = "event_textBox">
+          <div class = "event_title FCHcolor">
+            おもしろ写真deアニメーション
+          </div>
+          <div class = "event_point">
+            <table>
+              <tr>
+                <th class = "event_point_cap">日時</th>
+                <td class = "event_point_contents">
+                  <div class="event_point_contents-text">
+                    11月12日(土) 13日(日)<br>
+                    10:30-12:30(1回目)　14:00-16:00(2回目)<br>
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <th class = "event_point_cap">会場</th>
+                <td class = "event_point_contents">はこだてみらい館</td>
+              </tr>
+              <tr>
+                <th class = "event_point_cap">参加費</th>
+                <td class = "event_point_contents">
+                  <div class="event_point_contents-text">
+                    無料
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <th class = "event_point_cap">対象</th>
+                <td class = "event_point_contents">
+                  <div class="event_point_contents-text">
+                    小学生から大人まで　※保護者同伴も可
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <th class = "event_point_cap">定員</th>
+                <td class = "event_point_contents">
+                  <div class="event_point_contents-text">
+                    各回20名
+                  </div>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div class = "event_detail-short event_detail-overflow">
+            写真のおもしろさは、ただ記録することだけじゃありません。<br>
+            何気ない風景も、写真にすれば工夫次第で別世界に！<br>
+            はこだてみらい館で撮影したおもしろ写真に動きをつけて<br>
+            世界で一つのアニメーション作品を作ってみよう！<br>
+            ・監修：原田泰さん(公立はこだて未来大学教授)
+            <div class = "eventDetail_picBox">
+              <img class = "eventDetail_pic" src = "images/event/c-event8/01.gif">
+            </div>
+          </div>
+        </div>
+        <form action = "event_subscript.php" method = "get">
+          <div class = "subscription">
+            <input type="hidden" name="id" value="8">
+            <input type="submit" value="申し込む" class = "button">
+            <div class = "panel">
+              <p class = "panelLabel">応募終了</p>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div> --> 
+
+        <!-- <li>
+          <a href = "event.html#12">
+            <div class = "latestBox_kids">
+              <div class = "remaindays_kids">
+                <div class = "caption">
+                <script>countdown(20161113);</script>
+                </div>
+              </div>
+              <img src="images/event/event12.jpg" alt="パントマイムSHOW">
+              <div class = "eventText">
+                <p class = "eventsch caption KPHcolor">
+                  11月13日(日)
+                </p>
+                <p class = "eventtitle">パントマイムSHOW</p>
+                <p class = "eventplace caption">
+                  はこだてキッズプラザ
+                </p>
+              </div>
+            </div>
+          </a>
+        </li> --> 
+
+    <!-- <div class = "eventmenu" id="12">
+      <img class = "event_pic only_pc" src = "images/event/sq_event12.jpg"  alt = "パントマイムSHOW">
+      <img class = "event_pic only_sp" src = "images/event/event12.jpg" alt = "パントマイムSHOW">
+      <div class = "event_textBox_wrap">
+        <div class = "event_textBox">
+          <div class = "event_title KPHcolor">
+            パントマイムSHOW
+          </div>
+          <div class = "event_point">
+            <table>
+              <tr>
+                <th class = "event_point_cap">日時</th>
+                <td class = "event_point_contents">
+                  <div class="event_point_contents-text">
+                    11月13日(日)<br>
+                    12:00-12:15(1回目)　15:00-15:15(2回目)
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <th class = "event_point_cap">会場</th>
+                <td class = "event_point_contents">はこだてキッズプラザ　テラス前</td>
+              </tr>
+              <tr>
+                <th class = "event_point_cap">参加費</th>
+                <td class = "event_point_contents">
+                  <div class="event_point_contents-text">
+                    無料
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <th class = "event_point_cap">対象</th>
+                <td class = "event_point_contents">
+                  <div class="event_point_contents-text">
+                    小さい子から大きい子まで
+                  </div>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div class = "event_detail-short">
+            キッズプラザのスタッフによるいつも大盛り上がりのパントマイムショー！<br>
+            テラス前をステージに、いろんなネタを披露します。<br>
+            ショーの途中から子どもにも参加していただきます！
+          </div>
+        </div>
+        <form action = "event_subscript.php" method = "get">
+          <div class = "subscription">
+            <div class = "panel">
+              <p class = "panelLabel">※事前申込不要</p>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div> --> 

--- a/index.html
+++ b/index.html
@@ -69,48 +69,6 @@
     <div class = "flexslider">
       <ul class = "slides">
         <li>
-          <a href = "event.html#8">
-            <div class = "latestBox_future">
-              <div class = "remaindays_future">
-                <div class = "caption">
-                <script>countdown(20161112,20161113);</script>
-                </div>
-              </div>
-              <img src="images/event/event8.gif" alt="おもしろ写真deアニメーション">
-              <div class = "eventText">
-                <p class = "eventsch caption FCHcolor">
-                  11/12(土) 13(日)
-                </p>
-                <p class = "eventtitle">おもしろ写真deアニメーション</p>
-                <p class = "eventplace caption">
-                  はこだてみらい館
-                </p>
-              </div>
-            </div>
-          </a>
-        </li>
-        <li>
-          <a href = "event.html#12">
-            <div class = "latestBox_kids">
-              <div class = "remaindays_kids">
-                <div class = "caption">
-                <script>countdown(20161113);</script>
-                </div>
-              </div>
-              <img src="images/event/event12.jpg" alt="パントマイムSHOW">
-              <div class = "eventText">
-                <p class = "eventsch caption KPHcolor">
-                  11月13日(日)
-                </p>
-                <p class = "eventtitle">パントマイムSHOW</p>
-                <p class = "eventplace caption">
-                  はこだてキッズプラザ
-                </p>
-              </div>
-            </div>
-          </a>
-        </li>
-        <li>
           <a href = "event.html#9">
             <div class = "latestBox_future">
               <div class = "remaindays_future">
@@ -152,7 +110,7 @@
             </div>
           </a>
         </li>
-        <!-- <li>
+        <li>
           <a href = "event.html#13">
             <div class = "latestBox_kids">
               <div class = "remaindays_kids">
@@ -172,7 +130,7 @@
               </div>
             </div>
           </a>
-        </li> -->
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
写真アニメ消せって言われてたけど、よく見たらパントマイムも終わってたのでそれもついでに削除

あわせて、コメントアウトしていた直近のイベント部を復活